### PR TITLE
Changes groupset psi vector to a reference.

### DIFF
--- a/ChiModules/LinearBoltzmannSolver/GroupSet/lbs_groupset.cc
+++ b/ChiModules/LinearBoltzmannSolver/GroupSet/lbs_groupset.cc
@@ -12,7 +12,8 @@ extern ChiMPI& chi_mpi;
 
 //##############################################
 /**Groupset constructor.*/
-LBSGroupset::LBSGroupset()
+LBSGroupset::LBSGroupset(std::vector<double>& in_psi_new_local) :
+    psi_new_local(in_psi_new_local)
 {
   quadrature = nullptr;
   iterative_method = LinearBoltzmann::IterativeMethod::CLASSICRICHARDSON;

--- a/ChiModules/LinearBoltzmannSolver/GroupSet/lbs_groupset.h
+++ b/ChiModules/LinearBoltzmannSolver/GroupSet/lbs_groupset.h
@@ -76,10 +76,10 @@ public:
   chi_math::UnknownManager                     psi_uk_man;
   bool                                         psi_to_be_saved=false;
   size_t                                       num_psi_unknowns_local=0;
-  std::vector<double>                          psi_new_local;
+  std::vector<double>&                         psi_new_local;
 
   //npt_groupset.cc
-       LBSGroupset();
+       LBSGroupset(std::vector<double>& in_psi_new_local);
   void BuildDiscMomOperator(unsigned int scattering_order,
                             LinearBoltzmann::GeometryType geometry_type);
   void BuildMomDiscOperator(unsigned int scattering_order,

--- a/ChiModules/LinearBoltzmannSolver/lbs_linear_boltzmann_solver.h
+++ b/ChiModules/LinearBoltzmannSolver/lbs_linear_boltzmann_solver.h
@@ -94,6 +94,8 @@ public:
   std::vector<double> phi_new_local, phi_old_local;
   std::vector<double> delta_phi_local;
 
+  std::vector<std::vector<double>> groupset_psi_new_local;
+
  public:
   //00
   Solver();

--- a/ChiModules/LinearBoltzmannSolver/lua/lbs_groupset_ops.cc
+++ b/ChiModules/LinearBoltzmannSolver/lua/lbs_groupset_ops.cc
@@ -97,7 +97,8 @@ int chiLBSCreateGroupset(lua_State *L)
   }
 
   //============================================= Create groupset
-  solver->group_sets.emplace_back();
+  solver->groupset_psi_new_local.emplace_back();
+  solver->group_sets.emplace_back(solver->groupset_psi_new_local.back());
 
   lua_pushinteger(L,static_cast<lua_Integer>(solver->group_sets.size())-1);
   return 1;


### PR DESCRIPTION
A vector of vectors was created in LBS to store psi by groupset. These vectors are created when groupsets are created to establish the mapping from a vector with vector of vectors to a given groupset.